### PR TITLE
ENH: absorb explicit Portal block, fix few links, provide more hrefs

### DIFF
--- a/content/pages/features.rst
+++ b/content/pages/features.rst
@@ -25,8 +25,10 @@ provides all the necessary functionality to automatically index and search any
 data it was made aware of — whether it's one's personal data, the data of an
 entire lab, all the data of an institution, or a complete public data portal.
 
-The following demo shows how one can quickly find desired datasets,
-install them, and selectively obtain necessary files across multiple datasets.
+The following demo shows how one can quickly
+`find <http://docs.datalad.org/en/latest/generated/man/datalad-search.html>`__ desired datasets,
+`install <http://docs.datalad.org/en/latest/generated/man/datalad-install.html>`_
+them, and selectively obtain necessary files across multiple datasets.
 
 .. raw:: html
 
@@ -121,8 +123,8 @@ Reproducible Science
 ####################
 
 DataLad is an ideal tool for conducting reproducible science. It can track and
-`obtain shared data </for/dataconsumers.html>`__ and `publish results
-</for/datasharing.html>`__. Importantly, it jointly manages both analysis input
+`obtain shared data <#for-data-consumers>`__ and `publish results
+<#data-sharing>`__. Importantly, it jointly manages both analysis input
 data and the associated analysis code --- critical to reproduce any analysis.
 Lastly, DataLad is able to temporally capture the exact commands used to
 produce the results.
@@ -165,8 +167,9 @@ collected data across processing infrastructure, track provenance of derived
 data, and also updating datasets with more of freshly acquired data while
 relying on git's powerful merge mechanisms.
 
-Whenever the data are ready for public sharing, it is a `datalad publish` away,
-while also allowing to to easily control and restrict the public release to only
+Whenever the data are ready for public sharing, it is a
+`datalad publish <http://docs.datalad.org/en/latest/generated/man/datalad-publish.html>`_
+away, while also allowing to to easily control and restrict the public release to only
 data files which do not carry any possibly subject identifying information
 (e.g., non-defaced high-resolution anatomicals).
 

--- a/theme/templates/index.html
+++ b/theme/templates/index.html
@@ -13,15 +13,17 @@
   </div>
   <div id='cards'>
     <div class='card'>
-      <h2 class="icon-flashlight"><a href='/features.html#data-discovery'>Discover Data</a></h2>
+      <h2 class="icon-flashlight"><a href='/features.html#data-discovery'>Discover</a></h2>
       <p>DataLad has built-in support for <strong>metadata</strong> extraction
       and <strong>search</strong>. With only a few steps, you can search through
-      a large collection of readily available datasets and immediately download
+      <a href="/datasets.html">a large collection of readily available datasets</a>
+	  (from <a href="http://openfmri.org">OpenFMRI</a>,
+            <a href="http://crcns.org">CRCNS</a>, etc.) and immediately download
       them. <a href="/features.html#data-discovery">See more...</a></p>
     </div>
 
     <div class='card'>
-      <h2 class="icon-download"><a href='/features.html#for-data-consumers'>Consume Data</a></h2>
+      <h2 class="icon-download"><a href='/features.html#for-data-consumers'>Consume</a></h2>
       <p>DataLad offers direct <strong>access to individual files</strong>
       &mdash; great when you only need a few files from some large datasets for
       an analysis. Files in a dataset can be distributed across
@@ -32,7 +34,7 @@
     </div>
 
     <div class='card'>
-      <h2 class="icon-signal"><a href='/features.html#data-sharing'>Publish Data</a></h2>
+      <h2 class="icon-signal"><a href='/features.html#data-sharing'>Publish</a></h2>
       <p>DataLad supports sharing datasets with the <strong>public or just some
       colleagues</strong> on platforms that you are using already &mdash;
       <strong>no need for a central service</strong>. You have complete freedom
@@ -42,7 +44,7 @@
     </div>
 
     <div class='card'>
-      <h2 class="icon-cw"><a href='/features.html#reproducible-science'>Reproducibility</a></h2>
+      <h2 class="icon-cw"><a href='/features.html#reproducible-science'>Reproduce</a></h2>
       <p>DataLad provides <strong>joint management of analysis code <em>and</em> data</strong>.
       This enables you to comprehensively track the exact state of any analysis inputs that
       produced your results &mdash; across the entire lifetime of a project, and across
@@ -50,16 +52,10 @@
       <a href="/features.html#reproducible-science">See more...</a></p>
       <p></p>
     </div>
-
-    <div class='card'>
-      <h2 class="icon-sitemap"><a href='/datasets.html'>Data Portal</a></h2>
-      <p>The DataLad project operates a crawler that regularly indexes
-         datasets from scientific data portals such as
-         <a href="http://openfmri.org">OpenFMRI</a> and
-         <a href="http://crcns.org">CRCNS</a>, making them trivial to acquire
-         and work with using DataLad.
-         <!-- better link would be to some description of the underlying tech-->
-         Take a look at the <a href="/datasets.html">available datasets</a>.</p>
-    </div>
   </div>
+
+  <div class='download'>
+    <p><a href='/features.html'>Explore more features</a></p>
+  </div>
+
 {% endblock content %}


### PR DESCRIPTION
- Made entry boxes have uniform Imperative formulation (removed also 'data' since it is not just about data, and otherwise it is assumed)
- removed "Portal" and absorbed links into "Discover"
- added trailing button to guide into Features
- few other minor fixups etc

this is how it looks:
![index](http://www.onerussian.com/tmp/gkrellShoot_08-25-17_161629.png)

I think it would be nice if `Features` page provided even more of "seamless" pointers into documentation for related concepts/actions... this way users would get high level overview while being able to quickly get to the related details (also that is a part of my intention for those "[help]" links in the commands transcript for screencasts).