### PR TITLE
ENH: comment on SSH_USER variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PUBLISHCONF=$(BASEDIR)/publishconf.py
 
 SSH_HOST=kumo.ovgu.de
 SSH_PORT=22
+# Provide user with the trailing @, e.g. "joe@"
 SSH_USER=
 SSH_TARGET_DIR=/srv/datalad.org/
 RSYNC_OPTS = -rzlhv --delete --copy-links --exclude=_files


### PR DESCRIPTION
But FWIW I would like to reiterate that ~/.ssh/config solution is more scalable, e.g. we coud just have

```shell
Host datalad-website
   Hostname datalad.org
   Port 22
   User whoever
   # Use whenever behind some weird firewall needing to jump through another host
   #  ProxyCommand ssh -q -A gateway 'nc -w1 %h %p'
```

thus encapsulating all the knowledge about how to reach datalad-website host via ssh in a single place, possibly tuned for a particular user/network/scenario (easy to define multiple hosts sharing everything but not e.g. Hostname ;))