### PR TITLE
fix wrong link in integrations.json

### DIFF
--- a/content/static/integrations.json
+++ b/content/static/integrations.json
@@ -503,7 +503,7 @@
   "name": "DataLad Gooey",
   "website": "",
   "github": "https://github.com/datalad/datalad-gooey",
-  "docs": "https://docs.datalad.org/projects/datalad-dataverse/en/latest",
+  "docs": "https://docs.datalad.org/projects/gooey/en/latest/",
   "info": "",
   "logo": "datalad_gooey_logo.svg",
   "description": "This extesion provides a graphical user interface for DataLad, making key tasks more accessible and convenient",


### PR DESCRIPTION
 - change documentation link in the integration section so it references the gooey documentation instead of the datalad-dataverse documentation.