### PR TITLE
Ensure that the index page's copyright is always current

### DIFF
--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -86,7 +86,7 @@
 
         <p class="license"><small>
           content licensed <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">cc-by-sa</a>
-          <span class='break'>—</span> ©2015–2021 {{ AUTHOR }} <span class='break'>—</span>
+          <span class='break'>—</span> ©2015-<script>document.write(new Date().getFullYear())</script> {{ AUTHOR }} <span class='break'>—</span>
           unless <a rel="license" href='copyright.html'>indicated otherwise</a>
         </small></p>
       </div>


### PR DESCRIPTION
fixes #130

This is how it looks like when build locally:
![image](https://user-images.githubusercontent.com/29738718/221500338-da463883-f86b-44d8-b9f6-2014db63512d.png)
