### PR TITLE
A bunch of updates

### DIFF
--- a/content/pages/index.html
+++ b/content/pages/index.html
@@ -15,7 +15,7 @@
   <div class="distribits-teaser"> </div>
   <h2>Technologies for distributed data management</h2>
   <p>
-    The first distribits meeting will happen on April 18th to April 20th, 2024, at “Haus der Universität”, Düsseldorf, Germany,
+    The first distribits meeting will happen on April 4th to April 6th, 2024, at “Haus der Universität”, Düsseldorf, Germany,
     with the aim of bringing together enthusiasts of tools and workflows in the domain of distributed data. Join us!
   </p>
   <div class="overview-buttons">

--- a/content/static/github_contributors.json
+++ b/content/static/github_contributors.json
@@ -1,1 +1,270 @@
-
+[
+  {
+    "login": "AKSoo",
+    "avatar_url": "https://avatars.githubusercontent.com/u/7570456?v=4"
+  },
+  {
+    "login": "Aksoo",
+    "avatar_url": "https://avatars.githubusercontent.com/u/141905668?v=4"
+  },
+  {
+    "login": "AlexandreHutton",
+    "avatar_url": "https://avatars.githubusercontent.com/u/50920802?v=4"
+  },
+  {
+    "login": "Arshitha",
+    "avatar_url": "https://avatars.githubusercontent.com/u/10297203?v=4"
+  },
+  {
+    "login": "DisasterMo",
+    "avatar_url": "https://avatars.githubusercontent.com/u/49207524?v=4"
+  },
+  {
+    "login": "Remi-Gau",
+    "avatar_url": "https://avatars.githubusercontent.com/u/6961185?v=4"
+  },
+  {
+    "login": "TheChymera",
+    "avatar_url": "https://avatars.githubusercontent.com/u/950524?v=4"
+  },
+  {
+    "login": "TobiasKadelka",
+    "avatar_url": "https://avatars.githubusercontent.com/u/49553687?v=4"
+  },
+  {
+    "login": "TrellixVulnTeam",
+    "avatar_url": "https://avatars.githubusercontent.com/u/112716341?v=4"
+  },
+  {
+    "login": "adelavega",
+    "avatar_url": "https://avatars.githubusercontent.com/u/2774448?v=4"
+  },
+  {
+    "login": "adswa",
+    "avatar_url": "https://avatars.githubusercontent.com/u/29738718?v=4"
+  },
+  {
+    "login": "akeshavan",
+    "avatar_url": "https://avatars.githubusercontent.com/u/972008?v=4"
+  },
+  {
+    "login": "allcontributors[bot]",
+    "avatar_url": "https://avatars.githubusercontent.com/in/23186?v=4"
+  },
+  {
+    "login": "andycon",
+    "avatar_url": "https://avatars.githubusercontent.com/u/3965889?v=4"
+  },
+  {
+    "login": "aqw",
+    "avatar_url": "https://avatars.githubusercontent.com/u/765557?v=4"
+  },
+  {
+    "login": "arokem",
+    "avatar_url": "https://avatars.githubusercontent.com/u/118582?v=4"
+  },
+  {
+    "login": "asmacdo",
+    "avatar_url": "https://avatars.githubusercontent.com/u/1028657?v=4"
+  },
+  {
+    "login": "ayrustogaru",
+    "avatar_url": "https://avatars.githubusercontent.com/u/35329371?v=4"
+  },
+  {
+    "login": "bobknob23987",
+    "avatar_url": "https://avatars.githubusercontent.com/u/5871865?v=4"
+  },
+  {
+    "login": "bpinsard",
+    "avatar_url": "https://avatars.githubusercontent.com/u/1155388?v=4"
+  },
+  {
+    "login": "bpoldrack",
+    "avatar_url": "https://avatars.githubusercontent.com/u/10498301?v=4"
+  },
+  {
+    "login": "candleindark",
+    "avatar_url": "https://avatars.githubusercontent.com/u/12135617?v=4"
+  },
+  {
+    "login": "catetrai",
+    "avatar_url": "https://avatars.githubusercontent.com/u/18424941?v=4"
+  },
+  {
+    "login": "chrhaeusler",
+    "avatar_url": "https://avatars.githubusercontent.com/u/8115807?v=4"
+  },
+  {
+    "login": "christian-monch",
+    "avatar_url": "https://avatars.githubusercontent.com/u/17925232?v=4"
+  },
+  {
+    "login": "cs-hall",
+    "avatar_url": "https://avatars.githubusercontent.com/u/67027056?v=4"
+  },
+  {
+    "login": "da5nsy",
+    "avatar_url": "https://avatars.githubusercontent.com/u/3739866?v=4"
+  },
+  {
+    "login": "debanjum",
+    "avatar_url": "https://avatars.githubusercontent.com/u/6413477?v=4"
+  },
+  {
+    "login": "dependabot[bot]",
+    "avatar_url": "https://avatars.githubusercontent.com/in/29110?v=4"
+  },
+  {
+    "login": "driusan",
+    "avatar_url": "https://avatars.githubusercontent.com/u/498329?v=4"
+  },
+  {
+    "login": "effigies",
+    "avatar_url": "https://avatars.githubusercontent.com/u/83442?v=4"
+  },
+  {
+    "login": "eltociear",
+    "avatar_url": "https://avatars.githubusercontent.com/u/22633385?v=4"
+  },
+  {
+    "login": "emdupre",
+    "avatar_url": "https://avatars.githubusercontent.com/u/15017191?v=4"
+  },
+  {
+    "login": "eort",
+    "avatar_url": "https://avatars.githubusercontent.com/u/8819465?v=4"
+  },
+  {
+    "login": "gi114",
+    "avatar_url": "https://avatars.githubusercontent.com/u/17640807?v=4"
+  },
+  {
+    "login": "glalteva",
+    "avatar_url": "https://avatars.githubusercontent.com/u/14296143?v=4"
+  },
+  {
+    "login": "jbpoline",
+    "avatar_url": "https://avatars.githubusercontent.com/u/275048?v=4"
+  },
+  {
+    "login": "jdkent",
+    "avatar_url": "https://avatars.githubusercontent.com/u/12564882?v=4"
+  },
+  {
+    "login": "jhpb7",
+    "avatar_url": "https://avatars.githubusercontent.com/u/101269419?v=4"
+  },
+  {
+    "login": "jkosciessa",
+    "avatar_url": "https://avatars.githubusercontent.com/u/40263608?v=4"
+  },
+  {
+    "login": "josephmje",
+    "avatar_url": "https://avatars.githubusercontent.com/u/22102194?v=4"
+  },
+  {
+    "login": "jsheunis",
+    "avatar_url": "https://avatars.githubusercontent.com/u/10141237?v=4"
+  },
+  {
+    "login": "judithbomba",
+    "avatar_url": "https://avatars.githubusercontent.com/u/68907896?v=4"
+  },
+  {
+    "login": "jwodder",
+    "avatar_url": "https://avatars.githubusercontent.com/u/98207?v=4"
+  },
+  {
+    "login": "kimsin98",
+    "avatar_url": "https://avatars.githubusercontent.com/u/7570456?v=4"
+  },
+  {
+    "login": "kyleam",
+    "avatar_url": "https://avatars.githubusercontent.com/u/1297788?v=4"
+  },
+  {
+    "login": "lilikapa",
+    "avatar_url": "https://avatars.githubusercontent.com/u/14184487?v=4"
+  },
+  {
+    "login": "lisanmo",
+    "avatar_url": "https://avatars.githubusercontent.com/u/52251433?v=4"
+  },
+  {
+    "login": "loj",
+    "avatar_url": "https://avatars.githubusercontent.com/u/15157717?v=4"
+  },
+  {
+    "login": "m-wierzba",
+    "avatar_url": "https://avatars.githubusercontent.com/u/31971177?v=4"
+  },
+  {
+    "login": "marisaheckner",
+    "avatar_url": "https://avatars.githubusercontent.com/u/52243533?v=4"
+  },
+  {
+    "login": "matrss",
+    "avatar_url": "https://avatars.githubusercontent.com/u/9308656?v=4"
+  },
+  {
+    "login": "mattcieslak",
+    "avatar_url": "https://avatars.githubusercontent.com/u/170026?v=4"
+  },
+  {
+    "login": "mih",
+    "avatar_url": "https://avatars.githubusercontent.com/u/136479?v=4"
+  },
+  {
+    "login": "mikapfl",
+    "avatar_url": "https://avatars.githubusercontent.com/u/7226087?v=4"
+  },
+  {
+    "login": "mslw",
+    "avatar_url": "https://avatars.githubusercontent.com/u/11985212?v=4"
+  },
+  {
+    "login": "nhjjr",
+    "avatar_url": "https://avatars.githubusercontent.com/u/24777116?v=4"
+  },
+  {
+    "login": "nhjjreuter",
+    "avatar_url": "https://avatars.githubusercontent.com/u/24777116?v=4"
+  },
+  {
+    "login": "nicholsn",
+    "avatar_url": "https://avatars.githubusercontent.com/u/463344?v=4"
+  },
+  {
+    "login": "nobodyinperson",
+    "avatar_url": "https://avatars.githubusercontent.com/u/19148271?v=4"
+  },
+  {
+    "login": "oesteban",
+    "avatar_url": "https://avatars.githubusercontent.com/u/598470?v=4"
+  },
+  {
+    "login": "overlake333",
+    "avatar_url": "https://avatars.githubusercontent.com/u/28018084?v=4"
+  },
+  {
+    "login": "sappelhoff",
+    "avatar_url": "https://avatars.githubusercontent.com/u/9084751?v=4"
+  },
+  {
+    "login": "taylols",
+    "avatar_url": "https://avatars.githubusercontent.com/u/28018084?v=4"
+  },
+  {
+    "login": "tguiot",
+    "avatar_url": "https://avatars.githubusercontent.com/u/17005998?v=4"
+  },
+  {
+    "login": "vsoch",
+    "avatar_url": "https://avatars.githubusercontent.com/u/814322?v=4"
+  },
+  {
+    "login": "yarikoptic",
+    "avatar_url": "https://avatars.githubusercontent.com/u/39889?v=4"
+  }
+]

--- a/content/static/github_repositories.txt
+++ b/content/static/github_repositories.txt
@@ -1,3 +1,6 @@
 datalad/datalad
-datalad/datalad-metalad
+datalad/datalad-catalog
+datalad/datalad-container
+datalad/datalad-next
+datalad/datalad-registry
 datalad-handbook/book

--- a/content/static/integrations.json
+++ b/content/static/integrations.json
@@ -415,20 +415,6 @@
   ]
 },
 {
-  "name": "PASTA",
-  "website": "",
-  "github": "https://gitlab-public.fz-juelich.de/pasta",
-  "docs": "https://jugit.fz-juelich.de/pasta/main/-/wikis/home",
-  "info": "",
-  "logo": "",
-  "description": "This database for 'adaPtive mAterials Science meTa-dAta' uses DataLad for metadata capturing and synchronization.",
-  "tags": [
-    "materials science",
-    "metadata",
-    "data management"
-  ]
-},
- {
   "name": "Bitbucket",
   "website": "https://bitbucket.org/product",
   "github": "",

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -49,4 +49,5 @@ MENUITEMS = (
     ('learn more', '/#resources'),
     ('get support', '/#get-support'),
     ('cite', '/#cite'),
+    ('merchandise', 'https://www.hellotux.com/datalad'),
 )

--- a/theme/static/css/style.css
+++ b/theme/static/css/style.css
@@ -272,7 +272,7 @@ nav.card ul {
   bottom: 0;
   left: 0;
   right: 0;
-  width: 7em;
+  width: 8em;
   display: inline-flexbox;
   flex-wrap: wrap;
 }

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -86,7 +86,7 @@
 
         <p class="license"><small>
           content licensed <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">cc-by-sa</a>
-          <span class='break'>—</span> ©2015–2023 {{ AUTHOR }} <span class='break'>—</span>
+          <span class='break'>—</span> ©2015–2024 {{ AUTHOR }} <span class='break'>—</span>
           unless <a rel="license" href='copyright.html'>indicated otherwise</a>
         </small></p>
       </div>


### PR DESCRIPTION
This PR:
- adds more repositories from which to add contributors (next, catalog, container, registry)
- and re-adds the contributors list after locally regenerating it (it was empty for some reason)
- fixes the dates for distribits (was fixed in the image in a previous commit, but not the text)
- removes PASTA from the list of use cases, closes #141 
- updates copyright year
- adds a link to hellotux merchandise in the main menu, closes #143 