### PR TITLE
Fix broken link to Dataverse docs

### DIFF
--- a/content/static/integrations.json
+++ b/content/static/integrations.json
@@ -474,7 +474,7 @@
   "name": "Dataverse",
   "website": "",
   "github": "https://github.com/datalad/datalad-dataverse",
-  "docs": "https://docs.datalad.org/projects/datalad-dataverse/en/latest",
+  "docs": "https://docs.datalad.org/projects/dataverse/en/latest",
   "info": "",
   "logo": "dataverse.svg",
   "description": "This extension integrates DataLad with the widely used open source research data repository software, Dataverse",


### PR DESCRIPTION
The [previous link](https://docs.datalad.org/projects/datalad-dataverse/en/latest) for the 'datalad-dataverse' extension documentation yielded a 404 error code.